### PR TITLE
ci: fixed invalid semver suffix for container images

### DIFF
--- a/.github/workflows/main-workflow.yml
+++ b/.github/workflows/main-workflow.yml
@@ -105,20 +105,21 @@ jobs:
         # Only run if a new version was released AND we found the PR number
         if: steps.check_release.outputs.new_release_version != '' && env.PR_NUMBER != ''
         run: |
-          PR_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ env.PR_NUMBER }}"
+          # Pull the floating tag for the specific PR
+          FLOATING_PR_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ env.PR_NUMBER }}-latest"
           RELEASE_VERSION="${{ steps.check_release.outputs.new_release_version }}"
           RELEASE_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${RELEASE_VERSION}"
           LATEST_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
           
-          echo "Pulling PR image: ${PR_IMAGE}"
-          docker pull ${PR_IMAGE}
+          echo "Pulling floating PR image: ${FLOATING_PR_IMAGE}"
+          docker pull ${FLOATING_PR_IMAGE}
           
-          echo "Tagging ${PR_IMAGE} as release image: ${RELEASE_IMAGE}"
-          docker tag ${PR_IMAGE} ${RELEASE_IMAGE}
+          echo "Tagging ${FLOATING_PR_IMAGE} as release image: ${RELEASE_IMAGE}"
+          docker tag ${FLOATING_PR_IMAGE} ${RELEASE_IMAGE}
           docker push ${RELEASE_IMAGE}
           
-          echo "Tagging ${PR_IMAGE} as latest image: ${LATEST_IMAGE}"
-          docker tag ${PR_IMAGE} ${LATEST_IMAGE}
+          echo "Tagging ${FLOATING_PR_IMAGE} as latest image: ${LATEST_IMAGE}"
+          docker tag ${FLOATING_PR_IMAGE} ${LATEST_IMAGE}
           docker push ${LATEST_IMAGE}
           
           echo "Image push completed successfully for version ${RELEASE_VERSION}"

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -35,6 +35,22 @@ jobs:
         id: lint
         run: npm run lint
 
+      - name: Get base semantic version
+        id: base_semver
+        run: |
+          # Get most recent tag, default to 0.0.0 if none exists
+          LATEST_TAG=$(git describe --tags --abbrev=0 --match "v[0-9]*.[0-9]*.[0-9]*" 2>/dev/null || echo "v0.0.0")
+          BASE_VERSION="${LATEST_TAG#v}"
+          echo "BASE_VERSION=${BASE_VERSION}" >> $GITHUB_ENV
+          echo "base_version=${BASE_VERSION}" >> $GITHUB_OUTPUT
+          
+      - name: Construct PR Version Tag
+        id: pr_version
+        run: |
+          PR_TAG_VERSION="${{ env.BASE_VERSION }}-pr${{ github.event.pull_request.number }}"
+          echo "PR_TAG_VERSION=${PR_TAG_VERSION}" >> $GITHUB_ENV
+          echo "pr_tag_version=${PR_TAG_VERSION}" >> $GITHUB_OUTPUT
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -53,8 +69,14 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}
-          labels: ${{ steps.meta.outputs.labels }}
+          # TAGS: Add specific PR version tag and floating pr-NUMBER-latest tag
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.PR_TAG_VERSION }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-latest
+          # LABELS: Add specific PR version as label
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            org.opencontainers.image.version=${{ env.PR_TAG_VERSION }}
 
       - name: Comment on PR with image info
         uses: actions/github-script@v7
@@ -65,12 +87,12 @@ jobs:
             
             A new Docker image has been built and pushed to the GitHub Container Registry:
             
-            - Image: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}\`
+            - Image: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.PR_TAG_VERSION }}\`
             
             You can pull and run it with:
             \`\`\`bash
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}
-            docker run -p 8080:8080 ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}
+            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.PR_TAG_VERSION }}
+            docker run -p 8080:8080 ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.PR_TAG_VERSION }}
             \`\`\`
             
             This image will be used for deployment if this PR is merged.


### PR DESCRIPTION
* PRs will generate images tagged like 1.2.3-pr42 (based on the latest tag at build time) and pr-42-latest.
* The release workflow uses semantic-release to determine the official version (e.g., 1.3.0), pulls the pr-42-latest image, and tags it as 1.3.0 and latest.